### PR TITLE
Add information in debugging k3po.js in readme, 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,9 @@ module.exports = function (grunt) {
                     ui: 'mocha-k3po',
                     require: 'lib/testFrameworks/mocha-k3po.js',
                     captureFile: "build/testMochaK3po.txt",
+                    // timeout: 5000,
                     browser: {
+                        // debug: true,
                         desiredCapabilities: {
                             browserName: 'firefox'
                         }

--- a/README.md
+++ b/README.md
@@ -127,3 +127,19 @@ Configuration via Grunt
 
 1. `npm install`
 1. `grunt`
+
+### Debugging the browser
+
+By default the browser closes after the test, in case of test failures you can pass the debug flag to the browser
+configuration as shown to keep it open.  This allows access to the browser javascript console.
+
+```JavaScript
+browser: {
+    desiredCapabilities: {
+        browserName: 'firefox'
+    },
+    debug: true
+}
+
+```
+

--- a/lib/browser/BrowserRunner.js
+++ b/lib/browser/BrowserRunner.js
@@ -37,9 +37,9 @@ BrowserRunner.prototype.loadOrigin = function () {
         _this._browser.url(this._origin);
     }
 
-    return _this._browser.execute(RemoteScriptRunner).execute(function (resources) {
-        k3po = new RemoteScriptRunner(resources);
-    }, _this._resources).then();
+    return _this._browser.execute(RemoteScriptRunner).execute(function (resources, debug) {
+        k3po = new RemoteScriptRunner(resources, debug);
+    }, _this._resources, _this._debug).then();
 };
 
 BrowserRunner.prototype.getExceptions = function () {

--- a/lib/browser/RemoteScriptRunner.js
+++ b/lib/browser/RemoteScriptRunner.js
@@ -13,11 +13,12 @@ var window;
  */
 module.exports = function () {
 
-    RemoteScriptRunner = function RemoteScriptRunner(resources) {
+    RemoteScriptRunner = function RemoteScriptRunner(resources, debug) {
         this._state = "INITIAL";
         this._cmdQueue = [];
         this._eventListenerMap = [];
         this._eventAlreadyFiredEventMap = [];
+        this._debug = debug;
         for (var i = 0; i < resources.length; i++) {
             this.loadScript(resources[i]);
         }
@@ -138,7 +139,11 @@ module.exports = function () {
 
     RemoteScriptRunner.prototype.nextCommand = function () {
         if (this._cmdQueue.length > 0) {
-            return this._cmdQueue.shift();
+            var command = this._cmdQueue.shift();
+            if(this._debug) {
+                console.log("RemoteScriptRunner received command: " + command);
+            }
+            return command;
         }
         return null;
     };
@@ -153,6 +158,9 @@ module.exports = function () {
         var arg = null;
         var type = event.type;
 
+        if(this._debug) {
+            console.log("RemoteScriptRunner fired event: " + type);
+        }
         switch (type) {
             case "NOTIFIED":
                 arg = event.barrier;

--- a/test/testFrameworks/mocha-k3po_spec.js
+++ b/test/testFrameworks/mocha-k3po_spec.js
@@ -20,10 +20,10 @@ describe('WsClient', function () {
         ws.onmessage = function (event) {
             chai.assert.equal(event.data, echoText);
             ws.close();
+            done();
         };
 
         ws.onclose = ws.onerror = function () {
-            done();
         };
     });
 


### PR DESCRIPTION
& added some extra logging in the browser for when debugging was enabled.

@AdrianCozma Thanks for reporting the issue.  The bug was simply that the script executing did not close the WebSocket connection.  So the onclose callback with done was never called until k3po and the test was already terminated.  I figure this out but launching with the debug flag and looking at the browser console log after it ran.  At first I did not think there was enough logging so I added some more when the debug flag is added.  Then I noticed the onclose / done was being called after test completion.

As per k3po it self.  We should be able to programmatically increase the logging on k3po when it starts.  In maven we do that with a -X.  In the grunt-k3po plugin we call maven from javascript but we don't expose a way to do that.  we should.  I've filed this issue for it: https://github.com/k3po/grunt-k3po/issues/5.  It should be fairly straight forward if you want to have a look at it: https://github.com/k3po/grunt-k3po/issues/5.

With out that flag you need to wireshark the k3po control protocol.  That was what I was going to have you do in our call this morning but figured it would be easier to look to see if there was a debug flag.  This was to find out if the script was completing all the way.  As per the test failure, we saw a timeout but no script diff. This indicated that the test timeout but that the script returned with completion. Just FYI. 

Thanks, hope this works for you.  Everything is passing on my machine now.  As always feel free to ping me if you have more questions
